### PR TITLE
Better stack trace

### DIFF
--- a/HttpError.js
+++ b/HttpError.js
@@ -22,12 +22,20 @@ function HttpError (status, message, options) {
     if (options.debug) {
         this.debug = options.debug;
     }
+
+    // Stack Trace
+    if (Error.captureStackTrace) {
+        // if not IE
+        Error.captureStackTrace(this, this.constructor);
+    } else {
+        // in IE
+        this.stack = (new Error()).stack;
+    }
 }
 
 // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Example.3A_Custom_Error_Types
 HttpError.prototype = new Error();
 HttpError.prototype.constructor = HttpError;
-
 HttpError.prototype.name = 'HttpError';
 
 module.exports = HttpError;

--- a/index.js
+++ b/index.js
@@ -6,5 +6,6 @@
 'use strict';
 
 module.exports = {
-    http: require('./libs/fumble.http')
+    http: require('./libs/fumble.http'),
+    HttpError: require('./HttpError')
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fumble",
   "description": "Simple error objects in node. Created specifically to be used with the fetchr library and based on hapi.js' Boom.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Mo Kouli <mkouli@yahoo-inc.com>",
   "main": "index.js",
   "repository": {
@@ -29,6 +29,7 @@
     "webpack": "^1.5"
   },
   "pre-commit": [
+    "lint",
     "devtest"
   ],
   "keywords": [
@@ -36,7 +37,6 @@
     "fetchr",
     "error"
   ],
-
   "licenses": [
     {
       "type": "BSD",


### PR DESCRIPTION
@koulmomo

When I was debugging https://github.com/yahoo/fluxible-plugin-fetchr/issues/46 the stack trace wasn't very helpful and didn't point out which line in `fetchr` the error came from. This PR fixes it and will even work in IE.

Before:
![screen shot 2015-09-03 at 1 35 35 pm](https://cloud.githubusercontent.com/assets/759766/9670342/e38048de-5240-11e5-9371-56cc42572ef5.png)

After:
![screen shot 2015-09-03 at 1 34 44 pm](https://cloud.githubusercontent.com/assets/759766/9670347/e9605f8c-5240-11e5-9a29-c77cdaa3196f.png)