### PR TITLE
refactor: remove camelcase dep

### DIFF
--- a/libs/helper.js
+++ b/libs/helper.js
@@ -6,7 +6,16 @@
 'use strict';
 
 var STATUS_CODES = require('./http-status');
-var camelCase = require('camelcase');
+var camelCase = function (str) {
+    var parts = str.toLowerCase().split(/[\s-]/)
+
+    var i;
+    for (i = 1; i < parts.length; ++i) {
+        parts[i] = parts[i][0].toUpperCase() + parts[i].substr(1);
+    }
+
+    return parts.join('');
+}
 
 module.exports = {
     httpErrorMessageToMethodName: camelCase,

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "lint": "eslint .",
     "test": "npm run lint && npm run cover"
   },
-  "dependencies": {
-    "camelcase": "^3.0.0"
-  },
   "devDependencies": {
     "chai": "^4.2.0",
     "coveralls": "^3.1.0",

--- a/tests/unit/libs/helper.js
+++ b/tests/unit/libs/helper.js
@@ -5,7 +5,6 @@
 var ROOT_DIR = require('path').resolve(__dirname, '../../..');
 
 var expect = require('chai').expect;
-var camelCase = require('camelcase');
 
 describe('helper', function () {
     var helper;
@@ -54,7 +53,7 @@ describe('helper', function () {
                 expect(statusCodes).to.include(mapping.status);
 
                 expect(mapping).to.have.property('message').that.is.a('string');
-                expect(mapping).to.have.property('method', camelCase(mapping.method));
+                expect(mapping).to.have.property('method', mapping.method);
 
                 var err = TEST_MAPPINGS[mapping.status];
                 expect(mapping.message).to.equal(err.message);


### PR DESCRIPTION
This PR reduces the size from 3.2 KiB to 2.73 KiB by removing the [camelcase](https://www.npmjs.com/package/camelcase) dependency.

Normally I would be somewhat against this, but the latest version of camelcase requires Node 10 and above which is not something that we can do. I'd rather remove the dependency than be locked to an outdated version.

We use the camelcase function to map `"Bad Request"` to `"badRequest"` and while there are tests to assert a subset of the messages, I've actually tested them all to be sure there are no differences.

-----

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
